### PR TITLE
Set locale to utf-8 to support non-ASCII path on Windows

### DIFF
--- a/src/base.h
+++ b/src/base.h
@@ -53,6 +53,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include <locale.h>
 
 #if (-6 & 5) || CHAR_BIT != 8 || UINT_MAX < 0xffffffff || ULONG_MAX % 0xFFFF
 #error                                                                         \

--- a/src/core.c
+++ b/src/core.c
@@ -12966,6 +12966,8 @@ __cold static int mdbx_handle_env_pathname(MDBX_handle_env_pathname *ctx,
     return MDBX_EINVAL;
 
 #if defined(_WIN32) || defined(_WIN64)
+  setlocale(LC_ALL, ".utf8");
+
   const size_t wlen = mbstowcs(nullptr, pathname, INT_MAX);
   if (wlen < 1 || wlen > /* MAX_PATH */ INT16_MAX)
     return ERROR_INVALID_NAME;


### PR DESCRIPTION
According to https://github.com/isar/isar/issues/527 , this is a simple way to fix encoding issue.